### PR TITLE
fix: remove intro text next to article heading

### DIFF
--- a/layouts/post.html.heex
+++ b/layouts/post.html.heex
@@ -16,19 +16,13 @@
   <div class="container-custom">
     
     <!-- Header Section -->
-    <div class="header-grid">
+    <div class="header-grid header-grid-full">
         <div class="title-col">
             <h1><%= @page.title %></h1>
             <div class="category-wrapper">
                 <div class="category-line"></div>
                 <span class="category"><%= if @page.frontmatter["category"], do: @page.frontmatter["category"], else: "Post" %></span>
             </div>
-        </div>
-        <div class="intro-col">
-            <p class="header-intro">
-                <!-- Assuming an intro/hook in frontmatter for new layout, else empty -->
-                <%= if @page.frontmatter["intro"] do %><%= @page.frontmatter["intro"] %><% end %>
-            </p>
         </div>
     </div>
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -496,6 +496,10 @@ code {
   align-items: start;
 }
 
+.header-grid-full {
+  grid-template-columns: 1fr;
+}
+
 .header-grid h1 {
   font-family: "Playfair Display", serif;
   font-size: 52px;


### PR DESCRIPTION
## Summary
- Removes the introductory text column (`intro-col`) from the post layout so the heading stands alone
- Adds `.header-grid-full` CSS class to make the title take full container width

Closes #2