### PR TITLE
fix: remove post details and author from article page

### DIFF
--- a/layouts/post.html.heex
+++ b/layouts/post.html.heex
@@ -42,6 +42,13 @@
         <% end %>
     </div>
 
+    <!-- Post Details -->
+    <div class="post-details">
+        <div class="meta-info">
+            <%= if @page.date do %><%= Calendar.strftime(@page.date, "%B %d, %Y") %><% end %>
+        </div>
+    </div>
+
     <!-- Main Content -->
     <div class="content-body">
         <%= @content %>


### PR DESCRIPTION
## Summary
- Removes the "Post Details" subheading and author/date information section from the individual article page layout
- These elements are not needed in the current design

Closes #3