### PR TITLE
fix: remove title and leave logo

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -25,8 +25,7 @@
   <div class="nav-container">
     <div class="site-logo">
       <a href="<%= base %>/index.html">
-        <img src="<%= base %>/images/platform_Q_logo_small.webp" alt="Logo" style="height: 68px; vertical-align: middle; margin-right: 8px;">
-        <%= @site.title %>
+        <img src="<%= base %>/images/platform_Q_logo_small.webp" alt="<%= @site.title %>" style="height: 68px; vertical-align: middle;">
       </a>
     </div>
     <ul>


### PR DESCRIPTION
## Summary
- Removes the site title text from the navigation header
- Keeps only the logo image as the sole branding element
- Updates the logo `alt` attribute to use the site title for accessibility

Closes #6