### PR TITLE
chore: rename site to Platform Q Artificial Intelligence Ltd.

### DIFF
--- a/config/alkali.exs
+++ b/config/alkali.exs
@@ -2,7 +2,7 @@ import Config
 
 config :alkali,
   site: %{
-    title: "Platform Q.ai",
+    title: "Platform Q Artificial Intelligence Ltd.",
     url: "https://platformq.ai",
     author: "Platform Q",
     # Base path for URLs - use "" for relative links (works with file:// and web root)

--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "Platform Q Artificial Intelligence Ltd.",
+  "short_name": "Platform Q",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",


### PR DESCRIPTION
## Summary
- Updates the site title in `config/alkali.exs` from "Platform Q.ai" to "Platform Q Artificial Intelligence Ltd."
- Updates `site.webmanifest` name and short_name from placeholder values to match the real site name

Closes #7