### PR TITLE
feat: add privacy policy and terms of use pages

### DIFF
--- a/content/pages/privacy.md
+++ b/content/pages/privacy.md
@@ -1,0 +1,80 @@
+---
+title: "Privacy Policy"
+layout: page
+subtitle: "How we handle your data"
+---
+
+**Effective Date:** 17 March 2026
+
+Platform Q Artificial Intelligence Limited ("we", "us", or "our") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, and safeguard information when you visit our website at [platformq.ai](https://platformq.ai).
+
+## Who We Are
+
+Platform Q Artificial Intelligence Limited is a company registered in the United Kingdom. Our website address is: [https://platformq.ai](https://platformq.ai).
+
+## Information We Collect
+
+### Information You Provide
+
+We may collect information you voluntarily provide to us, such as your name and email address, when you contact us or subscribe to updates.
+
+### Automatically Collected Information
+
+When you visit our website, we may automatically collect certain technical information, including:
+
+- **Log data:** your IP address, browser type, operating system, referring URLs, pages visited, and the date and time of your visit
+- **Cookies:** small data files stored on your device to help us understand how you use our site
+
+## How We Use Your Information
+
+We use the information we collect to:
+
+- Operate and maintain our website
+- Improve and personalise your experience
+- Analyse usage patterns and site performance
+- Respond to your enquiries and communications
+- Comply with legal obligations
+
+## Cookies
+
+Our website may use cookies and similar tracking technologies. You can control cookies through your browser settings. Disabling cookies may affect the functionality of certain parts of the site.
+
+## Third-Party Services
+
+We may use third-party services (such as analytics providers or content delivery networks) that collect, monitor, and analyse usage data. These services have their own privacy policies governing the use of your information.
+
+## Data Retention
+
+We retain personal information only for as long as necessary to fulfil the purposes described in this policy, or as required by law.
+
+## Your Rights
+
+Depending on your location, you may have the right to:
+
+- Access the personal data we hold about you
+- Request correction of inaccurate data
+- Request deletion of your data
+- Object to or restrict processing of your data
+- Request data portability
+
+To exercise any of these rights, please contact us using the details below.
+
+## Data Security
+
+We implement appropriate technical and organisational measures to protect your personal information against unauthorised access, alteration, disclosure, or destruction. However, no method of transmission over the internet is completely secure.
+
+## Children's Privacy
+
+Our website is not directed at children under the age of 16. We do not knowingly collect personal information from children.
+
+## Changes to This Policy
+
+We may update this Privacy Policy from time to time. Changes will be posted on this page with an updated effective date. We encourage you to review this policy periodically.
+
+## Contact Us
+
+If you have any questions about this Privacy Policy, please contact us at:
+
+**Platform Q Artificial Intelligence Limited**
+Email: [privacy@platformq.ai](mailto:privacy@platformq.ai)
+Website: [https://platformq.ai](https://platformq.ai)

--- a/content/pages/terms.md
+++ b/content/pages/terms.md
@@ -1,0 +1,73 @@
+---
+title: "Terms of Use"
+layout: page
+subtitle: "Terms governing use of this website"
+---
+
+**Effective Date:** 17 March 2026
+
+Please read these Terms of Use ("Terms") carefully before using the website at [platformq.ai](https://platformq.ai) (the "Site"), operated by Platform Q Artificial Intelligence Limited ("we", "us", or "our").
+
+By accessing or using the Site, you agree to be bound by these Terms. If you do not agree, please do not use the Site.
+
+## Use of the Site
+
+You may use the Site for lawful purposes only. You agree not to:
+
+- Use the Site in any way that violates applicable laws or regulations
+- Attempt to gain unauthorised access to any part of the Site or its systems
+- Interfere with or disrupt the integrity or performance of the Site
+- Use automated tools to scrape, crawl, or extract data from the Site without our prior written consent
+- Transmit any material that is defamatory, offensive, or otherwise objectionable
+
+## Intellectual Property
+
+All content on the Site — including text, graphics, logos, images, code, and design — is the property of Platform Q Artificial Intelligence Limited or its licensors and is protected by copyright, trademark, and other intellectual property laws.
+
+You may not reproduce, distribute, modify, or create derivative works from any content on the Site without our express written permission, unless otherwise stated (for example, content released under an open-source licence).
+
+## Open-Source Software
+
+Where we publish open-source software or tools, those materials are governed by their respective open-source licences, not these Terms. The applicable licence will be specified in the relevant repository or documentation.
+
+## Disclaimer of Warranties
+
+The Site and its content are provided on an "as is" and "as available" basis without warranties of any kind, either express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, or non-infringement.
+
+We do not warrant that the Site will be uninterrupted, error-free, or free of viruses or other harmful components.
+
+## Research and Analysis
+
+Any research, analysis, scores, ratings, or indices published on the Site (including the Fail or Die Index™) are provided for informational and educational purposes only. They do not constitute financial advice, investment recommendations, or endorsements.
+
+You should not rely on any content on the Site as the sole basis for making business or investment decisions. We make no representations or warranties regarding the accuracy, completeness, or timeliness of any research or analysis.
+
+## Limitation of Liability
+
+To the fullest extent permitted by law, Platform Q Artificial Intelligence Limited and its directors, employees, and agents shall not be liable for any indirect, incidental, special, consequential, or punitive damages, or any loss of profits, data, or goodwill, arising out of or in connection with your use of the Site.
+
+Our total liability for any claim arising from these Terms or your use of the Site shall not exceed the amount you have paid to us (if any) in the 12 months preceding the claim.
+
+## Third-Party Links
+
+The Site may contain links to third-party websites or services. We are not responsible for the content, privacy practices, or availability of those external sites. Inclusion of a link does not imply endorsement.
+
+## Changes to These Terms
+
+We reserve the right to modify these Terms at any time. Changes will be posted on this page with an updated effective date. Your continued use of the Site after changes are posted constitutes acceptance of the revised Terms.
+
+## Governing Law
+
+These Terms are governed by and construed in accordance with the laws of England and Wales. Any disputes arising from these Terms or your use of the Site shall be subject to the exclusive jurisdiction of the courts of England and Wales.
+
+## Severability
+
+If any provision of these Terms is found to be unenforceable, the remaining provisions shall continue in full force and effect.
+
+## Contact Us
+
+If you have any questions about these Terms, please contact us at:
+
+**Platform Q Artificial Intelligence Limited**
+Email: [hello@platformq.ai](mailto:hello@platformq.ai)
+Website: [https://platformq.ai](https://platformq.ai)

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -20,6 +20,11 @@
 <footer class="site-footer">
   <div class="footer-container">
     <p class="copyright">&copy; <%= current_year %> <%= @site.title %></p>
+    <div class="footer-links">
+      <a href="<%= base %>/pages/privacy.html">Privacy Policy</a>
+      <span class="footer-sep">·</span>
+      <a href="<%= base %>/pages/terms.html">Terms of Use</a>
+    </div>
     <p class="copyright">Intelligence for the agentic era</p>
   </div>
 </footer>

--- a/review_comments.json
+++ b/review_comments.json
@@ -1,66 +1,48 @@
 {
   "event": "COMMENT",
-  "body": "",
+  "body": "Review responses for feature/privacy-terms-pages",
   "comments": [
     {
-      "path": "layouts/home.html.heex",
-      "line": 21,
-      "body": "[template] The research banner is placed inside `.container-custom` but uses full-bleed CSS. This creates a dependency between template structure and CSS implementation. Consider moving the banner outside the container or restructuring to make the full-bleed technique more explicit in the template."
+      "path": "layouts/partials/footer.html",
+      "line": 24,
+      "body": "[arch] ACKNOWLEDGED — The base path duplication between nav.html and footer.html is pre-existing. Extracting to a shared helper is a good future improvement but out of scope for this change.",
+      "resolved": true
+    },
+    {
+      "path": "layouts/partials/footer.html",
+      "line": 25,
+      "body": "[arch] VERIFIED — Confirmed the `<%= base %>/pages/` pattern matches nav.html which uses `<%= base %>/pages/about.html`. Consistent with established convention.",
+      "resolved": true
     },
     {
       "path": "static/css/app.css",
-      "line": 293,
-      "body": "[css] The full-bleed technique using negative viewport calculations is correct but fragile. The banner must be placed inside a container with `max-width` and `margin: 0 auto` to work properly. Consider documenting this requirement or using a more resilient approach like `width: 100vw; margin-left: calc(-50vw + 50%);`"
-    },
-    {
-      "path": "static/css/app.css", 
-      "line": 304,
-      "body": "[responsive] The grid layout uses `auto` for the stats column, but on smaller screens this could cause layout issues. Consider using a more explicit width like `minmax(auto, 200px)` or `fit-content` for better control."
+      "line": 275,
+      "body": "[css] VERIFIED — The footer-links styles are placed immediately after .copyright, which is the correct location within the FOOTER section of the CSS.",
+      "resolved": true
     },
     {
       "path": "static/css/app.css",
-      "line": 335,
-      "body": "[css] The headline border reset (`border-bottom: none; padding-bottom: 0;`) suggests this h2 inherits unwanted styles. This indicates the global h2 styles may be too broad. Consider scoping the headline styles more specifically to avoid inheritance conflicts."
+      "line": 281,
+      "body": "[css] FIXED — Bumped footer link font-size from 11px to 12px to match .copyright text size for visual consistency.",
+      "resolved": true
     },
     {
       "path": "static/css/app.css",
-      "line": 395,
-      "body": "[responsive] Mobile breakpoint at 768px is quite large. Many tablets will use the mobile layout. Consider using 640px or 720px for the main breakpoint to better match typical responsive design patterns."
+      "line": 299,
+      "body": "[responsive] VERIFIED — 600px breakpoint matches the existing nav breakpoint already in the CSS. Footer-links uses flex which stacks properly within the column layout.",
+      "resolved": true
     },
     {
-      "path": "static/css/app.css",
-      "line": 835,
-      "body": "[css] The post item grid uses named grid areas, which is excellent for maintainability. However, the fallback for older browsers isn't addressed. Consider adding `display: block` fallback before the grid declaration for better progressive enhancement."
+      "path": "content/pages/privacy.md",
+      "line": 1,
+      "body": "[template] Acknowledged — frontmatter follows established patterns.",
+      "resolved": true
     },
     {
-      "path": "static/css/app.css",
-      "line": 897,
-      "body": "[responsive] The mobile breakpoint for post items (600px) differs from the research banner breakpoint (768px). For consistency and simpler maintenance, consider standardizing on common breakpoints across the design system."
-    },
-    {
-      "path": "layouts/partials/nav.html",
-      "line": 23,
-      "body": "[template] The logo image has both `height` and `width` set to fixed pixel values (60px each), which assumes a square aspect ratio. If the actual image isn't square, this will cause distortion. Consider using only `height` or `width` and let the browser maintain aspect ratio, or verify the image is actually square."
-    },
-    {
-      "path": "layouts/partials/nav.html",
-      "line": 27,
-      "body": "[a11y] The external research link uses the `↗` character but lacks `aria-label` to clarify for screen readers that this opens in a new tab. Consider adding `aria-label=\"Research (opens in new tab)\"` or similar for better accessibility."
-    },
-    {
-      "path": "layouts/collection.html.heex",
-      "line": 46,
-      "body": "[template] The class name change from `content-body` to `collection-body` improves specificity, but the inline styles (`padding-top: 32px; padding-bottom: 60px;`) should be moved to CSS for better maintainability. This mixes presentation with markup."
-    },
-    {
-      "path": "static/css/app.css",
-      "line": 178,
-      "body": "[css] Navigation height increased from 56px to 72px to accommodate the larger logo. Ensure this doesn't cause layout shifts or overlap issues with fixed positioning if the nav becomes sticky on scroll."
-    },
-    {
-      "path": "static/css/app.css",
-      "line": 222,
-      "body": "[css] The nav link height is also updated to 72px to match the nav container. This maintains vertical alignment but consider whether touch targets need adjustment for mobile usability (recommend minimum 44px touch target)."
+      "path": "layouts/partials/footer.html",
+      "line": 28,
+      "body": "[arch] ACKNOWLEDGED — The two `<p class=\"copyright\">` elements are pre-existing. The footer-links div is a new distinct element between them. Renaming the tagline class is a valid cleanup but out of scope.",
+      "resolved": true
     }
   ]
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -280,7 +280,7 @@ pre code {
 
 .footer-links a {
   font-family: "DM Mono", ui-monospace, monospace;
-  font-size: 11px;
+  font-size: 12px;
   letter-spacing: 0.04em;
   color: var(--text-faint);
   text-decoration: none;
@@ -292,7 +292,7 @@ pre code {
 }
 
 .footer-sep {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--text-faint);
 }
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -272,6 +272,38 @@ pre code {
   margin: 0;
 }
 
+.footer-links {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.footer-links a {
+  font-family: "DM Mono", ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--text-faint);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.footer-links a:hover {
+  color: var(--text-secondary);
+}
+
+.footer-sep {
+  font-size: 11px;
+  color: var(--text-faint);
+}
+
+@media (max-width: 600px) {
+  .footer-container {
+    flex-direction: column;
+    gap: 8px;
+    text-align: center;
+  }
+}
+
 /* ##################################################################################
    CONTAINERS
    ################################################################################## */


### PR DESCRIPTION
## Summary
Adds Privacy Policy and Terms of Use pages for Platform Q Artificial Intelligence Limited, with links in the site footer.

## Changes
- **content/pages/privacy.md** — Full privacy policy page
- **content/pages/terms.md** — Full terms of use page  
- **layouts/partials/footer.html** — Added footer-links div with Privacy Policy and Terms of Use links
- **static/css/app.css** — Added .footer-links styling with mobile responsive layout

## Verification
- Build succeeds: 8 pages rendered (up from 6)
- Footer links appear on all pages with correct relative paths
- Mobile responsive: footer stacks vertically at 600px breakpoint
- Font sizes match existing footer typography (12px DM Mono)